### PR TITLE
Adding overrides support for Command-T.

### DIFF
--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -241,11 +241,19 @@ module CommandT
     end
 
 		def read_overrides
-			if File.file?(@override_definitions_file)
-				file_contents = IO.read(@override_definitions_file)
-				ruby_obj = YAML::load(file_contents)
-				@overrides = ruby_obj["overrides"]
-			else
+			begin 
+				if File.file?(@override_definitions_file)
+					file_contents = IO.read(@override_definitions_file)
+					ruby_obj = YAML::load(file_contents)
+					if ruby_obj.has_key?("overrides")
+						@overrides = ruby_obj["overrides"]
+					else 
+						raise "Key does not exist"
+					end
+				else 
+					raise "IO Error"
+				end
+			rescue
 				@overrides = Hash.new()
 			end	
 		end	


### PR DESCRIPTION
Hey Wincent,

Joseph Huttner here; we communicated some over e-mail and your site's support forums.  Cutting to the chase, I took your advice from the thread and incorporated it into this pull request I am sending you.

https://wincent.com/issues/1710

To use the functionality, create a .command-t.yaml file in the dir where you launch VIM, and use the following syntax:

<pre>
overrides: {
  a : path/to/some/file.php,
  b : path/to/another/file.php,
  cto : .command-t.yaml
} 
</pre>
