### PR TITLE
Support for an overrides file.

### DIFF
--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -241,11 +241,19 @@ module CommandT
     end
 
 		def read_overrides
-			if File.file?(@override_definitions_file)
-				file_contents = IO.read(@override_definitions_file)
-				ruby_obj = YAML::load(file_contents)
-				@overrides = ruby_obj["overrides"]
-			else
+			begin 
+				if File.file?(@override_definitions_file)
+					file_contents = IO.read(@override_definitions_file)
+					ruby_obj = YAML::load(file_contents)
+					if ruby_obj.has_key?("overrides")
+						@overrides = ruby_obj["overrides"]
+					else 
+						raise "Key does not exist"
+					end
+				else 
+					raise "IO Error"
+				end
+			rescue
 				@overrides = Hash.new()
 			end	
 		end	


### PR DESCRIPTION
User-defined key patterns allow for:

Opening stubborn files more quickly.  (Especially useful if the command-t search algo doesn't jive well with the filename)

Memorizing keystrokes needed to open commonly-used files.

To use: 
Where you launch vim, create a file named .command-t.yaml

Define an overrides hash:

```
 overrides:  {
     cc : public/js/asynchronous_call.js,
     af : controllers/user/anonymous_friend.py
 }
```

Typing "cc" within command-T will put the corresponding file at the top of your hit list.  Just hit Enter and it opens.
