### PR TITLE
Option to cache the scan directory

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -444,6 +444,16 @@ Following is a list of all available options:
       on the screen rather than moving as the number of matches changes during
       typing.
 
+                                                *g:CommandTCachePath*
+  |g:CommandTCachePath|                          boolean (default: 0)
+
+      When this setting is off (the default) scans will always take place from
+      the current working directory. Turning this option on causes the
+      directory vim was started in to be cached, and scans to take place from
+      this cached directory instead of the current working directory. The
+      cached directory can be changed by passing a directory argument to
+      :CommandT.
+
 As well as the basic options listed above, there are a number of settings that
 can be used to override the default key mappings used by Command-T. For
 example, to set <C-x> as the mapping for cancelling (dismissing) the Command-T

--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -31,11 +31,15 @@ module CommandT
       @prompt = Prompt.new
       set_up_max_height
       set_up_finder
+      @path = VIM::pwd
     end
 
     def show
+      unless get_bool('g:CommandTCachePath')
+        @path = VIM::pwd
+      end
       # optional parameter will be desired starting directory, or ""
-      @path           = File.expand_path(::VIM::evaluate('a:arg'), VIM::pwd)
+      @path           = File.expand_path(::VIM::evaluate('a:arg'), @path)
       @finder.path    = @path
       @initial_window = $curwin
       @initial_buffer = $curbuf


### PR DESCRIPTION
My vimrc contains an autocommand to change the working directory to that of each buffer:
    autocmd BufEnter \* lcd %:p:h
This makes it easier to edit files inside the same directory, but interferes with how Command-T wants to work with the cwd for each scan.

I've created a patch with a new option to cache the scan directory @path, unless a new path is explicitly passed to :CommandT.  There may be others with a similar autocmd or other reasons to not want cwd changes to affect Command-T.  I hope you'll consider it for inclusion.

Thanks,

-Kevin
