### PR TITLE
Option to reverse match order in the match window

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -460,6 +460,16 @@ Following is a list of all available options:
       on the screen rather than moving as the number of matches changes during
       typing.
 
+                                                *g:CommandTMatchWindowReverse*
+  |g:CommandTMatchWindowReverse|                  boolean (default: 0)
+
+      When this setting is off (the default) the matches will appear from
+      top to bottom with the topmost being selected. Turning it on causes the
+      matches to be reversed so the best match is at the bottom and the
+      initially selected match is the bottom most. This may be preferable if
+      you want the best match to appear in a fixed location on the screen
+      but still be near the prompt at the bottom.
+
 As well as the basic options listed above, there are a number of settings that
 can be used to override the default key mappings used by Command-T. For
 example, to set <C-x> as the mapping for cancelling (dismissing) the Command-T

--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -157,7 +157,8 @@ module CommandT
       @initial_buffer   = $curbuf
       @match_window     = MatchWindow.new \
         :prompt               => @prompt,
-        :match_window_at_top  => get_bool('g:CommandTMatchWindowAtTop')
+        :match_window_at_top  => get_bool('g:CommandTMatchWindowAtTop'),
+        :match_window_reverse => get_bool('g:CommandTMatchWindowReverse')
       @focus            = @prompt
       @prompt.focus
       register_for_key_presses

--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -33,6 +33,7 @@ module CommandT
 
     def initialize options = {}
       @prompt = options[:prompt]
+      @reverse_list = options[:match_window_reverse]
 
       # save existing window dimensions so we can restore them later
       @windows = []
@@ -153,6 +154,7 @@ module CommandT
         @selection += 1
         print_match(@selection - 1) # redraw old selection (removes marker)
         print_match(@selection)     # redraw new selection (adds marker)
+        @window.cursor = [@selection+1, 0]
       else
         # (possibly) loop or scroll
       end
@@ -163,6 +165,7 @@ module CommandT
         @selection -= 1
         print_match(@selection + 1) # redraw old selection (removes marker)
         print_match(@selection)     # redraw new selection (adds marker)
+        @window.cursor = [@selection+1, 0]
       else
         # (possibly) loop or scroll
       end
@@ -170,9 +173,15 @@ module CommandT
 
     def matches= matches
       if matches != @matches
-        @matches =  matches
-        @selection = 0
+        if @reverse_list
+          @matches =  matches.reverse
+          @selection = @matches.length - 1
+        else
+          @matches =  matches
+          @selection = 0
+        end
         print_matches
+        @window.cursor = [@selection+1, 0]
       end
     end
 


### PR DESCRIPTION
Added a new option CommandTMatchWindowReverse which allows you to reverse the order of the matches, bottom being closest match instead of top, this way it's closest to the prompt.

```
                                            *g:CommandTMatchWindowReverse*
```

  |g:CommandTMatchWindowReverse|                  boolean (default: 0)

```
  When this setting is off (the default) the matches will appear from
  top to bottom with the topmost being selected. Turning it on causes the
  matches to be reversed so the best match is at the bottom and the
  initially selected match is the bottom most. This may be preferable if
  you want the best match to appear in a fixed location on the screen
  but still be near the prompt at the bottom.
```
