### PR TITLE
Use 'tab drop' rather than 'tabe' for CommandTAcceptSelectionTab

### DIFF
--- a/plugin/command-t.vim
+++ b/plugin/command-t.vim
@@ -91,7 +91,7 @@ function CommandTAcceptSelection()
 endfunction
 
 function CommandTAcceptSelectionTab()
-  ruby $command_t.accept_selection :command => 'tabe'
+  ruby $command_t.accept_selection :command => 'tab drop'
 endfunction
 
 function CommandTAcceptSelectionSplit()


### PR DESCRIPTION
Using 'tab drop' checks if the file is already open in a tab. If it is, it will select that tab, otherwise it will create a new tab as usual.
