### PR TITLE
Allow external finders and opening behaviors

### DIFF
--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -241,6 +241,10 @@ module CommandT
     end
 
     def open_selection selection, options = {}
+      if @active_finder.respond_to? :open
+          @active_finder.open(selection, options)
+          return
+      end
       command = options[:command] || default_open_command
       selection = File.expand_path selection, @path
       selection = relative_path_under_working_directory selection

--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -21,10 +21,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-require 'command-t/finder/buffer_finder'
+require 'command-t/finder/basic_finder'
 require 'command-t/finder/file_finder'
 require 'command-t/match_window'
 require 'command-t/prompt'
+require 'command-t/scanner/buffer_scanner'
 require 'command-t/vim/path_utilities'
 
 module CommandT
@@ -33,23 +34,26 @@ module CommandT
 
     def initialize
       @prompt = Prompt.new
-      @buffer_finder = CommandT::BufferFinder.new
+      @buffer_finder = CommandT::BasicFinder.new CommandT::BufferScanner.new
       set_up_file_finder
       set_up_max_height
     end
 
+    def show_finder finder
+      @active_finder = finder
+      show
+    end
+
     def show_buffer_finder
       @path          = VIM::pwd
-      @active_finder = @buffer_finder
-      show
+      show_finder @buffer_finder
     end
 
     def show_file_finder
       # optional parameter will be desired starting directory, or ""
       @path             = File.expand_path(::VIM::evaluate('a:arg'), VIM::pwd)
       @file_finder.path = @path
-      @active_finder    = @file_finder
-      show
+      show_finder @file_finder
     rescue Errno::ENOENT
       # probably a problem with the optional parameter
       @match_window.print_no_such_file_or_directory

--- a/ruby/command-t/finder/basic_finder.rb
+++ b/ruby/command-t/finder/basic_finder.rb
@@ -22,14 +22,13 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 require 'command-t/ext' # CommandT::Matcher
-require 'command-t/scanner/buffer_scanner'
 require 'command-t/finder'
 
 module CommandT
-  class BufferFinder < Finder
-    def initialize
-      @scanner = BufferScanner.new
+  class BasicFinder < Finder
+    def initialize scanner
+      @scanner = scanner
       @matcher = Matcher.new @scanner, :always_show_dot_files => true
     end
-  end # class BufferFinder
+  end # class BasicFinder
 end # CommandT


### PR DESCRIPTION
These changes let Ruby code outside of CommandT subclass Finder and have CommandT use their finder to display the list of things to open. It also asks the finder if it'd like to handle opening the selection before using the default.

You can see it in action in [my Java navigation plugin](https://github.com/groves/scim/blob/7c8b5a9965b7d0a83050c64ddc96c664619f7894/plugin/scim.vim#L59). The plugin knows a list of Java class names and where docs or source are for them. It creates a new scanner that shows those classes, and when one is selected, the finder calls back out to my plugin to open them. Ruby and Python code working together!
