### PR TITLE
New option: g:CommandTMinHeight

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -406,6 +406,13 @@ Following is a list of all available options:
       If set to 0, the window will occupy as much of the available space as
       needed to show matching entries.
 
+                                               *g:CommandTMinHeight*
+  |g:CommandTMinHeight|                          number (default: 0)
+
+      The minimum height in lines the match window is allowed to shrink to.
+      If set to 0, will default to a single line. If set above the max height,
+      will default to |g:CommandTMaxHeight|.
+
                                                *g:CommandTAlwaysShowDotFiles*
   |g:CommandTAlwaysShowDotFiles|                 boolean (default: 0)
 

--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -36,6 +36,7 @@ module CommandT
       @buffer_finder = CommandT::BufferFinder.new
       set_up_file_finder
       set_up_max_height
+      set_up_min_height
     end
 
     def show_buffer_finder
@@ -70,6 +71,7 @@ module CommandT
 
     def flush
       set_up_max_height
+      set_up_min_height
       set_up_file_finder
     end
 
@@ -158,7 +160,8 @@ module CommandT
       @match_window     = MatchWindow.new \
         :prompt               => @prompt,
         :match_window_at_top  => get_bool('g:CommandTMatchWindowAtTop'),
-        :match_window_reverse => get_bool('g:CommandTMatchWindowReverse')
+        :match_window_reverse => get_bool('g:CommandTMatchWindowReverse'),
+        :min_height           => @min_height
       @focus            = @prompt
       @prompt.focus
       register_for_key_presses
@@ -167,6 +170,12 @@ module CommandT
 
     def set_up_max_height
       @max_height = get_number('g:CommandTMaxHeight') || 0
+    end
+
+    def set_up_min_height
+      set_up_max_height if @max_height.nil?
+      min_height = get_number('g:CommandTMinHeight') || 0
+      @min_height = (@max_height == 0 || min_height <= @max_height) ? min_height : @max_height
     end
 
     def set_up_file_finder


### PR DESCRIPTION
Added a new option (g:CommandTMinHeight) for controlling the minimum height in lines the match window is allowed to shrink to.

My use case is to set the g:CommandTMinHeight to the same value as g:CommandTMaxHeight so the results don't jump around when you're typing.

Others might like to set it to a value higher than 1 but lower than g:CommandTMaxHeight.
