### PR TITLE
Ensure nnoremap is used

### DIFF
--- a/plugin/command-t.vim
+++ b/plugin/command-t.vim
@@ -32,11 +32,11 @@ command -nargs=? -complete=dir CommandT call <SID>CommandTShowFileFinder(<q-args
 command CommandTFlush call <SID>CommandTFlush()
 
 if !hasmapto(':CommandT<CR>')
-  silent! nmap <unique> <silent> <Leader>t :CommandT<CR>
+  silent! nnoremap <unique> <silent> <Leader>t :CommandT<CR>
 endif
 
 if !hasmapto(':CommandTBuffer<CR>')
-  silent! nmap <unique> <silent> <Leader>b :CommandTBuffer<CR>
+  silent! nnoremap <unique> <silent> <Leader>b :CommandTBuffer<CR>
 endif
 
 function s:CommandTRubyWarning()


### PR DESCRIPTION
This fixes a bug when the user redefines : to ;
Previously \t and \b would not work in this case.
