### PR TITLE
Fix CommandTJump

### DIFF
--- a/ruby/command-t/scanner/jump_scanner.rb
+++ b/ruby/command-t/scanner/jump_scanner.rb
@@ -47,7 +47,7 @@ module CommandT
     end
 
     def jumps
-      VIM::capture 'silent jumps'
+      VIM::capture('silent jumps').split("\n")
     end
   end # class JumpScanner
 end # module CommandT


### PR DESCRIPTION
Previously, the jump scanner was pulling in a string jumplist, where it
needed an array of jumps. Fixed.
