### PR TITLE
On the fly highlighting of search string

### DIFF
--- a/ruby/command-t/vim.rb
+++ b/ruby/command-t/vim.rb
@@ -30,6 +30,10 @@ module CommandT
       ::VIM::evaluate('has("syntax")').to_i != 0
     end
 
+    def self.has_conceal?
+      ::VIM::evaluate('has("conceal")').to_i != 0
+    end
+
     def self.pwd
       ::VIM::evaluate 'getcwd()'
     end


### PR DESCRIPTION
- does nothing if vim wasn't compiled with +conceal
- underlines first instance of each character as you type

This is sort of how quicksilver works, so for instance:

if you type cmaw you would see this (fake underlining):

```
ruby/command-t/match_window.rb
     - - -           -
```

It'd be easy to change the highlighting to be a color instead, or even to make it configurable by the user.

While I was in there, I also changed some class variables to constants, as their values never changed.
