### PR TITLE
Add option to auto-path to git-root

### DIFF
--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -48,9 +48,27 @@ module CommandT
       show
     end
 
+    def traverse_to_git_top
+      path = Dir.pwd
+      while !File.directory?(path + "/.git")
+        return Dir.pwd if path == "/"
+        path = File.expand_path(path + "/..")
+      end
+      path
+    end
+
     def show_file_finder
       # optional parameter will be desired starting directory, or ""
-      @path             = File.expand_path(::VIM::evaluate('a:arg'), VIM::pwd)
+
+      arg = ::VIM::evaluate('a:arg')
+      if arg && arg.size > 0
+        @path = File.expand_path(arg, VIM::pwd)
+      elsif get_bool("g:CommandTTraverseToGitTop")
+        @path = traverse_to_git_top
+      else
+        @path = VIM::pwd
+      end
+
       @active_finder    = file_finder
       file_finder.path  = @path
       show


### PR DESCRIPTION
I like Command-T a lot, but am not quite ready to give up flying around subdirectories while I work in order to use it.  This patch allows the user to set the default search directory to be the first parent directory that contains the ".git" folder.  If it's not found in the upper path, we default back to pwd.

Could be generalized for other SCM marker files and such (I'd be willing to do so if you wanted the patch), but you get the general idea.
