### PR TITLE
Remove relative line numbers and color columns in the match window

### DIFF
--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -80,6 +80,12 @@ module CommandT
           'setlocal textwidth=0'        # don't hard-wrap (break long lines)
         ].each { |command| ::VIM::command command }
 
+        # don't show the color column
+        ::VIM::command 'setlocal colorcolumn=0' if exists('+colorcolumn')
+
+        # don't show relative line numbers
+        ::VIM::command 'setlocal norelativenumber' if exists('relativenumber')
+
         # sanity check: make sure the buffer really was created
         raise "Can't find GoToFile buffer" unless $curbuf.name.match /GoToFile\z/
         @@buffer = $curbuf


### PR DESCRIPTION
Call :setlocal norelativenumber and :set colorcolumn=0 after opening a
new match window so they won't show up in the match split. These extra
commands are not added to the existing commands array, as these are
7.3 features and need some feature detection to make sure they exist
first.
