### PR TITLE
Silence warnings on BufLeave by adding patch from https://wincent.com/issues/1778

### DIFF
--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -103,8 +103,8 @@ module CommandT
       # by some unexpected means of dismissing or leaving the Command-T window
       # (eg. <C-W q>, <C-W k> etc)
       ::VIM::command 'autocmd! * <buffer>'
-      ::VIM::command 'autocmd BufLeave <buffer> ruby $command_t.leave'
-      ::VIM::command 'autocmd BufUnload <buffer> ruby $command_t.unload'
+      ::VIM::command 'autocmd BufLeave <buffer> silent! ruby $command_t.leave'
+      ::VIM::command 'autocmd BufUnload <buffer> silent! ruby $command_t.unload'
 
       @has_focus  = false
       @selection  = nil


### PR DESCRIPTION
I am often getting BufLeave warnings. I don't see the benefit in showing those warnings, so I added a silencer based on the patch submitted at https://wincent.com/issues/1778. I think the change is very small and useful as it seems to frustrate many people to keep seeing those warnings. 

It would probably be good to understand why those warnings occur in the first place (I think it has something to do with using :bd possibly, but I am not sure). But in either case, the warnings can be killed. Thanks for a great plugin :)
