### PR TITLE
Fire WinEnter autocommands when leaving Command-T and re-entering original buffer

### DIFF
--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -68,6 +68,7 @@ module CommandT
           ::VIM::command "silent b #{@initial_buffer.name}"
         else
           ::VIM::command "silent b #{@initial_buffer.number}"
+          ::VIM::command "doautocmd WinEnter *"
         end
       end
     end


### PR DESCRIPTION
If a user opens the Command-T window and the closes it without changing buffers, either by hitting `<Esc>` or by selecting the current buffer from the list, `WinEnter` autocommands are not fired when focus moves back to the editing window.

This patch corrects this behavior by explicitly triggering the autocommands when the Command-T window is closed. I'm not that familiar with Command-T's code, so if there's a better approach to this, please advise.