### PR TITLE
Turn line numbers off in the match window

### DIFF
--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -77,7 +77,8 @@ module CommandT
           'setlocal nocursorline',      # don't highlight line cursor is on
           'setlocal nospell',           # spell-checking off
           'setlocal nobuflisted',       # don't show up in the buffer list
-          'setlocal textwidth=0'        # don't hard-wrap (break long lines)
+          'setlocal textwidth=0',       # don't hard-wrap (break long lines)
+          'setlocal nonumber'           # no line numbers
         ].each { |command| ::VIM::command command }
 
         # sanity check: make sure the buffer really was created


### PR DESCRIPTION
If I `set number`, in my .vimrc, then use commandT, the highlighted matches in the match window will wrap to the 2nd line (I have softwrap on) as they'll be too long.  This change just does `setlocal nonumber` along with the other setlocal commands.
