### PR TITLE
Revert ad45f0e, which breaks :CommandT with a path argument

### DIFF
--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -214,6 +214,13 @@ module CommandT
       end
     end
 
+    # Backslash-escape space, \, |, %, #, "
+    def sanitize_path_string str
+      # for details on escaping command-line mode arguments see: :h :
+      # (that is, help on ":") in the Vim documentation.
+      str.gsub(/[ \\|%#"]/, '\\\\\0')
+    end
+
     def default_open_command
       if !get_bool('&hidden') && get_bool('&modified')
         'sp'
@@ -244,9 +251,14 @@ module CommandT
 
     def open_selection selection, options = {}
       command = options[:command] || default_open_command
-
+      selection = File.expand_path selection, @path
+      selection = relative_path_under_working_directory selection
+      selection = sanitize_path_string selection
       ensure_appropriate_window_selection
+
       @active_finder.open_selection command, selection, options
+      # was:
+      # ::VIM::command "silent #{command} #{selection}"
     end
 
     def map key, function, param = nil

--- a/ruby/command-t/finder.rb
+++ b/ruby/command-t/finder.rb
@@ -22,7 +22,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 require 'command-t/ext' # CommandT::Matcher
-require 'command-t/vim/path_utilities'
 
 module CommandT
   # Encapsulates a Scanner instance (which builds up a list of available files
@@ -49,24 +48,11 @@ module CommandT
     end
 
     def open_selection command, selection, options = {}
-      selection = File.expand_path selection, @path
-      selection = relative_path_under_working_directory selection
-      selection = sanitize_path_string selection
-
-      ::VIM::command "silent #{command} #{selection}"
+        ::VIM::command "silent #{command} #{selection}"
     end
 
     def path= path
       @scanner.path = path
-    end
-
-  private
-
-    # Backslash-escape space, \, |, %, #, "
-    def sanitize_path_string str
-      # for details on escaping command-line mode arguments see: :h :
-      # (that is, help on ":") in the Vim documentation.
-      str.gsub(/[ \\|%#"]/, '\\\\\0')
     end
   end # class Finder
 end # CommandT


### PR DESCRIPTION
I noticed that all of my custom mappings to do CommandT in subdirectories broke after pulling master. I bisected and found that this commit broke it:

ad45f0e  (3 months)   <Noon Silk>           Moved some functions around

By the commit message, I assume that this change was not intentional. Reverting fixes the bug, which seems like the right short-term solution since it was only a refactoring.
