### PR TITLE
Make selection acceptance commands configurable

### DIFF
--- a/plugin/command-t.vim
+++ b/plugin/command-t.vim
@@ -109,15 +109,15 @@ function CommandTAcceptSelection()
 endfunction
 
 function CommandTAcceptSelectionTab()
-  ruby $command_t.accept_selection :command => 'tabe'
+  ruby $command_t.accept_selection :command => $command_t.tab_command
 endfunction
 
 function CommandTAcceptSelectionSplit()
-  ruby $command_t.accept_selection :command => 'sp'
+  ruby $command_t.accept_selection :command => $command_t.split_command
 endfunction
 
 function CommandTAcceptSelectionVSplit()
-  ruby $command_t.accept_selection :command => 'vs'
+  ruby $command_t.accept_selection :command => $command_t.vsplit_command
 endfunction
 
 function CommandTToggleFocus()

--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -163,6 +163,18 @@ module CommandT
       @match_window.unload
     end
 
+    def tab_command
+      get_string('g:CommandTAcceptSelectionTabCommand') || 'tabe'
+    end
+
+    def split_command
+      get_string('g:CommandTAcceptSelectionSplitCommand') || 'sp'
+    end
+
+    def vsplit_command
+      get_string('g:CommandTAcceptSelectionVSplitCommand') || 'vs'
+    end
+
   private
 
     def show
@@ -225,7 +237,7 @@ module CommandT
       if !get_bool('&hidden') && get_bool('&modified')
         'sp'
       else
-        'e'
+        get_string('g:CommandTAcceptSelectionCommand') || 'e'
       end
     end
 


### PR DESCRIPTION
Opening a file in a tab opens a new tab even if a tab or buffer containing the very same file already exists. By making the selection acceptance commands configurable, one may prevent this kind of behavior, i.e. like this:

```
set switchbuf=usetab

function! GotoOrOpen(...)
  for file in a:000
    if bufexists(file)
      exec "sb " . file
    else
      exec "tabe " . file
    endif
  endfor
endfunction

command! -nargs=+ GotoOrOpen call GotoOrOpen("<args>")

let g:CommandTAcceptSelectionTabCommand = 'GotoOrOpen'
```

If there is any other way to achieve this without applying the pull request, please enlighten me! :)

Regards,
Ole Petter
