### PR TITLE
Set synmaxcol to avoid match highlighting errors

### DIFF
--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -99,6 +99,7 @@ module CommandT
         ::VIM::command "syntax match CommandTSelection \"^#{SELECTION_MARKER}.\\+$\""
         ::VIM::command 'syntax match CommandTNoEntries "^-- NO MATCHES --$"'
         ::VIM::command 'syntax match CommandTNoEntries "^-- NO SUCH FILE OR DIRECTORY --$"'
+        ::VIM::command 'setlocal synmaxcol=9999'
 
         if VIM::has_conceal?
           ::VIM::command 'setlocal conceallevel=2'


### PR DESCRIPTION
The new match highlight feature uses <commandt></commandt> as conceal
markers per match. If the user has set a low synmaxcol (in order to
speed up syntax highlighting in files with long lines), the concealed
markers can quickly bring the character count of the line past the
synmaxcol value, causing all markers past the value to be shown.

This can be demonstrated by setting a low synmaxcol, then opening a new
match window in this project's root:

:set synmaxcol=20 | CommandT

" Search for `//`

> fixtures/bar/abc
>   fixtures/</commandt>bar<commandt>/</commandt>xyz
>   fixtures/</commandt>foo<commandt>/</commandt>beta
