### PR TITLE
Command-T is unable to open files that have names starting from the plus sign (+)

### DIFF
--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -260,6 +260,7 @@ module CommandT
       selection = File.expand_path selection, @path
       selection = relative_path_under_working_directory selection
       selection = sanitize_path_string selection
+      selection = File.join('.', selection) if selection =~ /^\+/
       ensure_appropriate_window_selection
 
       @active_finder.open_selection command, selection, options


### PR DESCRIPTION
Hi,

People who are working with, for instance, MATLAB would appreciate this patch since, according to the naming convension of MATLAB, package names have to start from '+', but Command-T (just like Vim inself) fails to open such names.

Regards,
Ivan
