### PR TITLE
Clear status line after closing the match window.

### DIFF
--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -67,7 +67,7 @@ module CommandT
     end
 
     def hide
-      @match_window.close
+      @match_window.leave
       if VIM::Window.select @initial_window
         if @initial_buffer.number == 0
           # upstream bug: buffer number misreported as 0


### PR DESCRIPTION
This fixes an issue where the status line is not properly cleared after closing the match window.
