### PR TITLE
Use https urls for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/vimball"]
 	path = vendor/vimball
-	url = git://github.com/tomtom/vimball.rb.git
+	url = https://github.com/tomtom/vimball.rb.git
 [submodule "vendor/vimscriptuploader"]
 	path = vendor/vimscriptuploader
-	url = git://github.com/tomtom/vimscriptuploader.rb.git
+	url = https://github.com/tomtom/vimscriptuploader.rb.git


### PR DESCRIPTION
Please, use https urls for submodules. It simplifies the life of anyone using git behind restrictive firewalls.
