### PR TITLE
Ignore hughe benchmark.yml file in exported archives.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data/benchmark.yml export-ignore


### PR DESCRIPTION
This file bumps the release archive size from 37,4 kB to 2.2 MB. This is
quite huge spase saving for Fedora's SRPM package.
