### PR TITLE
This patch fixed two 'compatibility' issues of command-t related to Ruby

### DIFF
--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -290,8 +290,8 @@ module CommandT
 
     def register_for_key_presses
       # "normal" keys (interpreted literally)
-      numbers     = ('0'..'9').to_a.join
-      lowercase   = ('a'..'z').to_a.join
+      numbers     = '0123456789'
+      lowercase   = 'abcdefghijklmnopqrstuvwxyz'
       uppercase   = lowercase.upcase
       punctuation = '<>`@#~!"$%&/()=+*-_.,;:?\\\'{}[] ' # and space
       (numbers + lowercase + uppercase + punctuation).each_byte do |b|

--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -23,6 +23,11 @@
 
 require 'ostruct'
 require 'command-t/settings'
+if RUBY_VERSION=='1.8.5'
+  # refer to https://www.ruby-forum.com/topic/157574
+  require 'jcode'
+end
+
 
 module CommandT
   class MatchWindow
@@ -328,8 +333,8 @@ module CommandT
     # for the match.
     #
     def match_with_syntax_highlight match
-      highlight_chars = @prompt.abbrev.downcase.chars.to_a
-      match.chars.inject([]) do |output, char|
+      highlight_chars = @prompt.abbrev.downcase.each_char.to_a
+      match.each_char.inject([]) do |output, char|
         if char.downcase == highlight_chars.first
           highlight_chars.shift
           output.concat [MH_START, char, MH_END]


### PR DESCRIPTION
1.8.5 on my CentOS 5.4 box.

Vim 7.4 issues some error messages on CentOS 5.4:

```
1. NoMethodError: undefined method `each_char' for "":String

2. NoMethodError: undefined method `[]' for nil:NilClas
```

It turns out that there is no String.chars method in Ruby version 1.8.5.

```
   $ ruby --version ruby 1.8.5 (2006-08-25) [x86_64-linux]
```

In lieu of 'chars' method used in 'ruby/command-t/match_window.rb', I use
'each_char.to_a' method.

I also hard coded the numbers in function 'register_for_key_presses' from

```
    numbers     = ('0'..'9').to_a.join 
```

to 
        numbers = ('0'..'9').to_a.join   # not as smart but always work

The reason is that the range syntax doesn't work ('0'..'9') in my box, which
caused the second error message. It could be more of a ruby issue specific to
my box or has to do with my configuration than a bug or incompatibility issue
with CommandT. But the change still justifies for it will work in viturally on
all ruby versions in all situtaions. 
