### PR TITLE
Always prepend space to -DPROCESSOR_COUNT.

### DIFF
--- a/ruby/command-t/extconf.rb
+++ b/ruby/command-t/extconf.rb
@@ -99,6 +99,6 @@ RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
 count = processor_count
 count = 1 if count < 0   # sanity check
 count = 32 if count > 32 # sanity check
-RbConfig::MAKEFILE_CONFIG['DEFS'] += "-DPROCESSOR_COUNT=#{count}"
+RbConfig::MAKEFILE_CONFIG['DEFS'] += " -DPROCESSOR_COUNT=#{count}"
 
 create_makefile('ext')


### PR DESCRIPTION
This prevents issues when something is already declared in DEFS.
