### PR TITLE
add a note that the github repository is no longer maintained and point to the official repository

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -1,3 +1,6 @@
+ATTENTION: This repository is no longer being updated. See the official repository at
+ [http://git.wincent.com/command-t.git](http://git.wincent.com/command-t.git).
+
 *command-t.txt* Command-T plug-in for Vim         *command-t*
 
 CONTENTS                                        *command-t-contents*


### PR DESCRIPTION
I recently went to update my command-t plugin and noticed there hadn't been any updates in several months. After doing a Google search I saw that there were more recent updates in the "official" repository. I thought it would be helpful to other users to have a note on the readme pointing to the official repo.

Thanks for the awesome plugin!
