### PR TITLE
Util.processor_count method works correctly.

### DIFF
--- a/ruby/command-t/util.rb
+++ b/ruby/command-t/util.rb
@@ -21,6 +21,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+require 'rbconfig'
+
 module CommandT
   module Util
     class << self


### PR DESCRIPTION
RbConfig was not imported in util.rb. As a result processor_count always
returned 1 from its rescue-branch.
