### PR TITLE
Fix index out of bounds bug

### DIFF
--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -160,7 +160,7 @@ module CommandT
     end
 
     def select_next
-      if @selection < @matches.length - 1
+      if @selection < [@matches.length, max_lines].min - 1
         @selection += 1
         print_match(@selection - 1) # redraw old selection (removes marker)
         print_match(@selection)     # redraw new selection (adds marker)


### PR DESCRIPTION
Currently if you try to scroll past the bottom of the list when there are more matches than can be displayed, you get a nasty index out of bounds exception.

This fixes it.
