### PR TITLE
Include stdint.h for uint8_t

### DIFF
--- a/ruby/command-t/watchman.c
+++ b/ruby/command-t/watchman.c
@@ -13,6 +13,7 @@
 #error no st.h header found
 #endif
 
+#include <stdint.h>     /* for uint8_t */
 #include <fcntl.h>      /* for fcntl() */
 #include <sys/errno.h>  /* for errno */
 #include <sys/socket.h> /* for recv(), MSG_PEEK */


### PR DESCRIPTION
Some compilers will be unable to compile this file without stdint.h.
