### PR TITLE
Change submodule urls (git -> https)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "vendor/vimball"]
 	path = vendor/vimball
-	url = git://github.com/tomtom/vimball.rb.git
+	url = https://github.com/tomtom/vimball.rb.git
 [submodule "vendor/vimscriptuploader"]
 	path = vendor/vimscriptuploader
-	url = git://github.com/tomtom/vimscriptuploader.rb.git
+	url = https://github.com/tomtom/vimscriptuploader.rb.git
 [submodule "vendor/vroom"]
 	path = vendor/vroom
 	url = https://github.com/google/vroom.git


### PR DESCRIPTION
To work around too strict firewalls that block git's smart protocol port 9418
Also makes `.gitmodules` consistent
