### PR TITLE
Fix ArgumentError bug

### DIFF
--- a/ruby/command-t/scanner/file_scanner/ruby_file_scanner.rb
+++ b/ruby/command-t/scanner/file_scanner/ruby_file_scanner.rb
@@ -47,6 +47,8 @@ module CommandT
         end
       rescue Errno::EACCES
         # skip over directories for which we don't have access
+      rescue ArgumentError
+        # skip over bad file names
       end
     end # class RubyFileScanner
   end # class FileScanner


### PR DESCRIPTION
Hello, Greg. Thanks for a great tool.
Pls, consider this patch to fix https://wincent.com/issues/2154 . This bug appears when command-t encounters some files coming from cp1251 systems (e.g. cloned from perforce).
