### PR TITLE
Add methods useful for status lines

### DIFF
--- a/autoload/commandt.vim
+++ b/autoload/commandt.vim
@@ -61,6 +61,30 @@ function commandt#CommandTFlush()
   endif
 endfunction
 
+function commandt#CommandTActiveFinder()
+  if has('ruby')
+    ruby ::VIM::command "return '#{$command_t.active_finder}'"
+  else
+    return ''
+  endif
+endfunction
+
+function commandt#CommandTPath()
+  if has('ruby')
+    ruby ::VIM::command "return '#{($command_t.path.gsub(/'/, "''")}'"
+  else
+    return ''
+  endif
+endfunction
+
+function commandt#CommandTCheckBuffer(buffer_number)
+  if has('ruby')
+    execute 'ruby $command_t.return_is_own_buffer' a:buffer_number
+  else
+    return 0
+  endif
+endfunction
+
 if !has('ruby')
   finish
 endif

--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -19,6 +19,30 @@ module CommandT
       @prompt = Prompt.new
     end
 
+    def active_finder
+      @active_finder and @active_finder.class.name or ''
+    end
+
+    def path
+      @path or ''
+    end
+
+    def is_own_buffer buffer_number
+      if @match_window and buffer_number == @match_window.buffer_number
+        return true
+      else
+        return false
+      end
+    end
+
+    def return_is_own_buffer buffer_number
+      if is_own_buffer buffer_number
+        ::VIM::command 'return 1'
+      else
+        ::VIM::command 'return 0'
+      end
+    end
+
     def show_buffer_finder
       @path          = VIM::pwd
       @active_finder = buffer_finder

--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -111,6 +111,10 @@ module CommandT
       @window     = $curwin
     end
 
+    def buffer_number
+      @@buffer and @@buffer.number
+    end
+
     def close
       # Unlisted buffers like those provided by Netrw, NERDTree and Vim's help
       # don't actually appear in the buffer list; if they are the only such


### PR DESCRIPTION
I added three functions and corresponding methods that are useful for plugins like airline or powerline.

- `commandt#CommandTActiveFinder` should be used to determine whether path is to be shown and what kind of selection is being made.
- `commandt#CommandTPath` should be used to display a directory from which file finder is selecting a path.
- `commandt#CommandTCheckBuffer` should be used to determine whether Command-T specific stuff should be displayed at all.