### PR TITLE
Cursor saving now looks for newlines and removes them

### DIFF
--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -407,12 +407,12 @@ module CommandT
       #   Cursor xxx cleared                -> :hi! clear Cursor
       highlight = VIM::capture 'silent! 0verbose highlight Cursor'
 
-      if highlight =~ /^Cursor\s+xxx\s+links to (\w+)/
-        "link Cursor #{$~[1]}"
-      elsif highlight =~ /^Cursor\s+xxx\s+cleared/
+      if highlight =~ /^Cursor\s+xxx\s+links to (\w+)/m
+        "link Cursor #{$~[1]}".gsub(/[\n]/, " ")
+      elsif highlight =~ /^Cursor\s+xxx\s+cleared/m
         'clear Cursor'
-      elsif highlight =~ /Cursor\s+xxx\s+(.+)/
-        "Cursor #{$~[1]}"
+      elsif highlight =~ /Cursor\s+xxx\s+(.+)/m
+        "Cursor #{$~[1]}".gsub(/[\n]/, " ")
       else # likely cause E411 Cursor highlight group not found
         nil
       end


### PR DESCRIPTION
I changed the regexp matching to include newlines and then replaced the newlines in the vim command with space. Seems to work, but not very thoroughly tested. Also, I don't actually know Ruby, so forgive me if the code is clumsy.

Fix for issue #133 
