### PR TITLE
doc: CommandT needs to be built and run with the version of Ruby same as Vim

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -276,13 +276,30 @@ as follows:
   ruby extconf.rb
   make
 
-Note: If you are an RVM or rbenv user, you must perform the build using the
-same version of Ruby that Vim itself is linked against. This will often be the
-system Ruby, which can be selected before issuing the "make" command with one
-of the following commands:
+Note: If you are an RVM or rbenv user, you must build and run CommandT using
+the same version of Ruby that Vim itself is linked against. You can get the
+version by issuing following command inside Vim:
 
-  rvm use system
-  rbenv local system
+  :ruby puts "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
+
+You can either set system's default version of Ruby to the output of the above
+command or re-build Vim with a version of Ruby you prefer.
+
+To set the default version of Ruby, issue one of the following commands before
+the "make" command:
+
+  rvm --default use VERSION # the Ruby version which Vim is linked against
+  rbenv global VERSION
+
+To re-build Vim, for Mac OS X, you can simply use Homebrew to uninstall and
+re-install Vim with following commands:
+
+    brew uninstall vim
+    brew install vim
+
+For more information about Homebrew, see:
+
+    http://brew.sh
 
 Note: If you are on OS X Mavericks and compiling against MacVim, the default
 system Ruby is 2.0 but MacVim still links against the older 1.8.7 Ruby that is


### PR DESCRIPTION
If you are an RVM or rbenv user, CommandT has to be built and run with
the same version of Ruby that Vim is linked against. Otherwise CommandT
won't work. So you either have to set that version of Ruby as default or
you need to re-build Vim with a version of Ruby you prefer.