### PR TITLE
Fix handling output of ":hi Cursor" with link + definition

### DIFF
--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -404,10 +404,13 @@ module CommandT
       # transformed in a certain way in order to reapply the highlight:
       #   Cursor xxx guifg=bg guibg=fg      -> :hi! Cursor guifg=bg guibg=fg
       #   Cursor xxx links to SomethingElse -> :hi! link Cursor SomethingElse
+      #   Cursor xxx [definition]\nlinks to VisualNOS -> both of above
       #   Cursor xxx cleared                -> :hi! clear Cursor
       highlight = VIM::capture 'silent! 0verbose highlight Cursor'
 
-      if highlight =~ /^Cursor\s+xxx\s+links to (\w+)/m
+      if highlight =~ /^Cursor\s+xxx\s+(.+)\blinks to (\w+)/m
+        "Cursor #{$~[1]} | highlight! link Cursor #{$~[2]}".gsub(/\s+/, ' ')
+      elsif highlight =~ /^Cursor\s+xxx\s+links to (\w+)/m
         "link Cursor #{$~[1]}".gsub(/\s+/, ' ')
       elsif highlight =~ /^Cursor\s+xxx\s+cleared/m
         'clear Cursor'


### PR DESCRIPTION
This gets set up through my solarized theme:

    hi! link Cursor VisualNOS

`:hi Cursor` looks as follows then:

    Cursor         xxx ctermfg=8 ctermbg=12 guifg=bg guibg=fg
                       links to VisualNOS

Without this patch there's the following error when closing the match
window:

  > Error detected while processing function CommandTCancel:
  > line    1:
  > E416: missing equal sign: links to VisualNOS

This uses a hack to apply two `highlight` commands, and should maybe get
improved to return and handle a list of highlight definitions.