### PR TITLE
Use has("gui_running") to skip mapping of `<Esc>`

### DIFF
--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -371,7 +371,7 @@ module CommandT
           end
         else
           Array(value).each do |mapping|
-            unless mapping == '<Esc>' && ::VIM::evaluate('has("gui_running")') == 0
+            unless mapping == '<Esc>' && term =~ /\A(rxvt|screen|xterm|vt100)/
               map mapping, key
             end
           end

--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -371,7 +371,7 @@ module CommandT
           end
         else
           Array(value).each do |mapping|
-            unless mapping == '<Esc>' && term =~ /\A(screen|xterm|vt100)/
+            unless mapping == '<Esc>' && ::VIM::evaluate('has("gui_running")') == 0
               map mapping, key
             end
           end


### PR DESCRIPTION
This fixes/skips the mapping of `<Esc>` also for rxvt* terminals.

Without this patch the Up/Down keys in urxvt-unicode did not work
properly in the match window.

It seems like mapping Escape should only get done for the GUI, and not
being skipped for certain terminals.