### PR TITLE
Add option to ignore spaces in search term

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -865,6 +865,15 @@ Following is a list of all available options:
       environment ends up defaulting to an undesired encoding, such as
       "ASCII-8BIT".
 
+                                        *g:CommandTIgnoreSpacesInSearchTerm*
+  |g:CommandTIgnoreSpacesInSearchTerm|    boolean (default: 0)
+
+      When typing a search term into Command-T, use this option to have it
+      ignore spaces. Without this option set, it will search for literal
+      spaces inside file names.
+
+        
+
 As well as the basic options listed above, there are a number of settings that
 can be used to override the default key mappings used by Command-T. For
 example, to set <C-x> as the mapping for cancelling (dismissing) the Command-T

--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -261,7 +261,8 @@ module CommandT
         @prompt.abbrev,
         :case_sensitive => case_sensitive?,
         :limit          => match_limit,
-        :threads        => CommandT::Util.processor_count
+        :threads        => CommandT::Util.processor_count,
+        :ignore_spaces  => VIM::get_bool('g:CommandTIgnoreSpacesInSearchTerm'),
       )
       @match_window.matches = @matches
 

--- a/ruby/command-t/matcher.c
+++ b/ruby/command-t/matcher.c
@@ -123,6 +123,7 @@ VALUE CommandTMatcher_sorted_matches_for(int argc, VALUE *argv, VALUE self)
     VALUE always_show_dot_files;
     VALUE limit_option;
     VALUE never_show_dot_files;
+    VALUE ignore_spaces;
     VALUE options;
     VALUE paths;
     VALUE results;
@@ -141,10 +142,14 @@ VALUE CommandTMatcher_sorted_matches_for(int argc, VALUE *argv, VALUE self)
     limit_option = CommandT_option_from_hash("limit", options);
     threads_option = CommandT_option_from_hash("threads", options);
     sort_option = CommandT_option_from_hash("sort", options);
+    ignore_spaces = CommandT_option_from_hash("ignore_spaces", options);
 
     abbrev = StringValue(abbrev);
     if (case_sensitive != Qtrue)
         abbrev = rb_funcall(abbrev, rb_intern("downcase"), 0);
+
+    if (ignore_spaces == Qtrue)
+        abbrev = rb_funcall(abbrev, rb_intern("delete"), 1, rb_str_new2(" "));
 
     // get unsorted matches
     scanner = rb_iv_get(self, "@scanner");

--- a/spec/command-t/matcher_spec.rb
+++ b/spec/command-t/matcher_spec.rb
@@ -49,6 +49,19 @@ describe CommandT::Matcher do
       matches.map { |m| m.to_s }.should == ['Foo']
     end
 
+    it 'considers the space character to match a literal space' do
+      matches = matcher(*['path_no_space', 'path with/space']).sorted_matches_for('path space')
+      matches.map { |m| m.to_s}.should == ['path with/space']
+    end
+
+    context 'when the ignore_spaces option in specified' do
+      it 'ignores the space character' do
+        matches = matcher(*['path_no_space', 'path with/space']).sorted_matches_for('path space', {:ignore_spaces => true})
+        matches.map { |m| m.to_s}.should == ['path_no_space', 'path with/space']
+      end
+
+    end
+
     it 'considers the empty string to match everything' do
       matches = matcher('foo').sorted_matches_for('')
       matches.map { |m| m.to_s }.should == ['foo']


### PR DESCRIPTION
This PR adds an option to ignore spaces in search terms. With g:CommandTIgnoreSpacesInSearchTerm set, any spaces you type into the Command-T bar are ignored. This I believes mirrors some behaviour from Sublime Text that I have not as yet been able to unlearn!