### PR TITLE
Keep the current alternate file name when opening the GoToFile buffer

### DIFF
--- a/ruby/command-t/match_window.rb
+++ b/ruby/command-t/match_window.rb
@@ -48,7 +48,7 @@ module CommandT
         raise "Can't re-open GoToFile buffer" unless $curbuf.number == @@buffer.number
         $curwin.height = 1
       else        # creating match window for first time and set it up
-        ::VIM::command "silent! #{split_location} 1split GoToFile"
+        ::VIM::command "silent! keepalt #{split_location} 1split GoToFile"
         set 'bufhidden', 'unload' # unload buf when no longer displayed
         set 'buftype', 'nofile'   # buffer is not related to any file
         set 'modifiable', false   # prevent manual edits


### PR DESCRIPTION
The alternate file name is set to 'GoToFile' when the GoToFile buffer is opened. This can catch a user off guard if they run a Command-T command (that opens the GoToFile buffer), immediately cancel it with `<Esc>`, and then try to edit the alternate file with `<C-^>`.

I was previously using this mapping `nnoremap <expr> <BS> bufname('#') !=# 'GoToFile' ? "\<C-^>" : ''` to work around the issue.