### PR TITLE
Update Watchman binary protocol documentation URL

### DIFF
--- a/ruby/command-t/watchman.c
+++ b/ruby/command-t/watchman.c
@@ -379,7 +379,7 @@ VALUE watchman_load_hash(char **ptr, char *end) {
  * Templated arrays are arrays of hashes which have repetitive key information
  * pulled out into a separate "headers" prefix.
  *
- * @see https://github.com/facebook/watchman/blob/master/BSER.markdown
+ * @see https://github.com/facebook/watchman/blob/master/website/_docs/BSER.markdown
  */
 VALUE watchman_load_template(char **ptr, char *end) {
     int64_t header_items_count, i, row_count;

--- a/ruby/command-t/watchman.h
+++ b/ruby/command-t/watchman.h
@@ -8,7 +8,7 @@
  *
  * Methods for working with the Watchman binary protocol
  *
- * @see https://github.com/facebook/watchman/blob/master/BSER.markdown
+ * @see https://github.com/facebook/watchman/blob/master/website/_docs/BSER.markdown
  */
 
 /**


### PR DESCRIPTION
I noticed that this URL was 404ing, so I tracked down where I think it
moved to and updated the URL here. I considered referencing a commit
hash instead of master to prevent this from happening again but decided
against it because it will potentially be sending folks to outdated
documentation.