### PR TITLE
Use %zd to format ssize_t

### DIFF
--- a/ruby/command-t/watchman.c
+++ b/ruby/command-t/watchman.c
@@ -591,7 +591,7 @@ VALUE CommandTWatchmanUtils_query(VALUE self, VALUE query, VALUE socket) {
     if (sent == -1) {
         watchman_raise_system_call_error(errno);
     } else if (sent != query_len) {
-        rb_raise(rb_eRuntimeError, "expected to send %ld bytes but sent %ld",
+        rb_raise(rb_eRuntimeError, "expected to send %ld bytes but sent %zd",
             query_len, sent);
     }
 


### PR DESCRIPTION
Should fix the following warning:

```
watchman.c:594:36: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'ssize_t {aka int}' [-Wformat=]
         rb_raise(rb_eRuntimeError, "expected to send %ld bytes but sent %ld",
                                    ^
```

observed when building on armhf ([build log](https://buildd.debian.org/status/fetch.php?pkg=vim-command-t&arch=armhf&ver=3.0.2-1&stamp=1455968542))