### PR TITLE
In MacOSX 10.10 (at least), you also have to add -ixoff option

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -1134,7 +1134,7 @@ your terminal has frozen, but it hasn't.
 To disable flow control, add the following to your `.zshrc` or
 `.bash_profile`:
 
-  stty -ixon
+  stty -ixon -ixoff
 
 See the `stty` man page for more details.
 


### PR DESCRIPTION
In MacOSX 10.10 (at least), you also have to add -ixoff option to stty command in .bash_profile, to make \<Ctrl-S\> work (as seen on http://dallarosa.tumblr.com/post/31333511717/commandt-and-ctrl-s-on-mac-os-x)