### PR TITLE
update vim-plug install instructions

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -279,7 +279,7 @@ Anywhere between the calls to `plug#begin` and `plug#end` in your
 Command-T:
 
   call plug#begin()
-  Plugin 'wincent/command-t'
+  Plug 'wincent/command-t'
   call plug#end()
 
 To actually install the plug-in run `:PlugInstall` from inside Vim. After


### PR DESCRIPTION
It's supposed to by `Plug` instead of `Plugin`. See [vim-plug#README](https://github.com/junegunn/vim-plug#example)