### PR TITLE
Add untracked files to `git ls-files` output

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -799,6 +799,11 @@ Following is a list of all available options:
       If set to 1, Command-T will scan submodules (recursively) when using the
       "git" file scanner (see |g:CommandTFileScanner|).
 
+                                            *g:CommandTGitIncludeUntracked*
+  |g:CommandTGitIncludeUntracked|             boolean (default: 0)
+
+      If set to 1, Command-T will include untracked files when using the "git"
+      file scanner (see: |g:CommandTFileScanner|).
 
                                             *g:CommandTSCMDirectories*
   |g:CommandTSCMDirectories|    string (default: '.git,.hg,.svn,.bzr,_darcs')

--- a/ruby/command-t/controller.rb
+++ b/ruby/command-t/controller.rb
@@ -554,7 +554,8 @@ module CommandT
         :scan_dot_directories   => VIM::get_bool('g:CommandTScanDotDirectories'),
         :wild_ignore            => VIM::get_string('g:CommandTWildIgnore'),
         :scanner                => VIM::get_string('g:CommandTFileScanner'),
-        :git_scan_submodules    => VIM::get_bool('g:CommandTGitScanSubmodules')
+        :git_scan_submodules    => VIM::get_bool('g:CommandTGitScanSubmodules'),
+        :git_include_untracked  => VIM::get_bool('g:CommandTGitIncludeUntracked')
     end
 
     def help_finder

--- a/ruby/command-t/scanner/file_scanner.rb
+++ b/ruby/command-t/scanner/file_scanner.rb
@@ -27,6 +27,7 @@ module CommandT
         @scan_dot_directories = options[:scan_dot_directories] || false
         @wild_ignore          = options[:wild_ignore]
         @scan_submodules      = options[:git_scan_submodules] || false
+        @include_untracked    = options[:git_include_untracked] || false
         @base_wild_ignore     = wild_ignore
       end
 

--- a/ruby/command-t/scanner/file_scanner/git_file_scanner.rb
+++ b/ruby/command-t/scanner/file_scanner/git_file_scanner.rb
@@ -10,7 +10,11 @@ module CommandT
 
         def paths!
           Dir.chdir(@path) do
-            all_files = list_files(%w[git ls-files --exclude-standard -z])
+            command = %w[git ls-files --exclude-standard -cz]
+            if @include_untracked
+              command << %q(--others)
+            end
+            all_files = list_files(command)
 
             if @scan_submodules
               base = nil


### PR DESCRIPTION
It can be advantageous to search for untracked files when working on large changesets before staging changes. This PR adds support for searching untracked files in the git file scanner by passing the `-o/--others` flag.