### PR TITLE
Better install instructions for `vim-plug`

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -279,7 +279,7 @@ Anywhere between the calls to `plug#begin` and `plug#end` in your
 Command-T:
 
   call plug#begin()
-  Plugin 'wincent/command-t'
+  Plug 'wincent/command-t', {'do': 'cd ruby/command-t; ruby extconf.rb; make'}
   call plug#end()
 
 To actually install the plug-in run `:PlugInstall` from inside Vim. After


### PR DESCRIPTION
- `Plugin` → `Plug`
- Add post install command to build C extension