### PR TITLE
Update Git Scanner to Include Files Not in Index

### DIFF
--- a/ruby/command-t/scanner/file_scanner/git_file_scanner.rb
+++ b/ruby/command-t/scanner/file_scanner/git_file_scanner.rb
@@ -12,6 +12,12 @@ module CommandT
           Dir.chdir(@path) do
             all_files = list_files(%w[git ls-files --exclude-standard -z])
 
+            list_files('git status -u --porcelain -z').each do |result|
+              # git status "??" means file not yet added to the index
+              match = /^\?{2} (.+)/.freeze.match result
+              all_files << match[1] if match
+            end
+
             if @scan_submodules
               base = nil
               list_files(%w[


### PR DESCRIPTION
Include files not yet added to git index. (Any new file)

I didn't really intend for this to be used by anyone other than me, but just in case...