### PR TITLE
Fix command-t when using RVM

### DIFF
--- a/autoload/commandt.vim
+++ b/autoload/commandt.vim
@@ -202,7 +202,7 @@ ruby << EOF
     else
       $command_t = CommandT::Stub.new
     end
-  rescue LoadError
+  rescue LoadError, Gem::Ext::BuildError
     load_path_modified = false
     ::VIM::evaluate('&runtimepath').to_s.split(',').each do |path|
       lib = "#{path}/ruby"


### PR DESCRIPTION
This should fix the various issues that have been reported when using RVM with a different version locally than the system version.  Command-T still needs to be compiled with the system ruby but this prevents the error that occurs when opening vim.

Specifically I believe this fixes #175 and #76.