### PR TITLE
Fix command-t on when using RVM

### DIFF
--- a/autoload/commandt.vim
+++ b/autoload/commandt.vim
@@ -152,6 +152,13 @@ augroup END
 
 ruby << EOF
   # require Ruby files
+  EXCEPTIONS = [LoadError]
+  begin
+    require 'rubygems/ext'
+    EXCEPTIONS << Gem::Ext::BuildError if defined?(Gem::Ext::BuildError)
+  rescue LoadError
+  end
+
   begin
     require 'command-t'
 
@@ -167,7 +174,7 @@ ruby << EOF
     else
       $command_t = CommandT::Stub.new
     end
-  rescue LoadError, Gem::Ext::BuildError
+  rescue *EXCEPTIONS
     load_path_modified = false
     ::VIM::evaluate('&runtimepath').to_s.split(',').each do |path|
       lib = "#{path}/ruby"

--- a/autoload/commandt.vim
+++ b/autoload/commandt.vim
@@ -167,7 +167,7 @@ ruby << EOF
     else
       $command_t = CommandT::Stub.new
     end
-  rescue LoadError
+  rescue LoadError, Gem::Ext::BuildError
     load_path_modified = false
     ::VIM::evaluate('&runtimepath').to_s.split(',').each do |path|
       lib = "#{path}/ruby"


### PR DESCRIPTION
This should fix the various issues that have been reported when using RVM with a different version locally than the system version. Command-T still needs to be compiled with the system ruby but this prevents the error that occurs when opening vim.

Specifically I believe this fixes #175 and #76.

Sorry for the double pull requests, I realized #261 had an incorrect author on the commit so I created this pull request in its stead.