### PR TITLE
Fix turning */foo/* wildignore into a regexp

### DIFF
--- a/ruby/command-t/lib/command-t/vim.rb
+++ b/ruby/command-t/lib/command-t/vim.rb
@@ -81,11 +81,11 @@ module CommandT
           elsif pattern.match(%r{\A\*\.([^*]+)\z})
             # *.something (match file with extension at any level)
             '\.' + Regexp.escape($~[1]) + '\z'
+          elsif pattern.match(%r{\A\*/([^/]+)/\*\z})
+            # */something/* (match directories at any level)
+            '(\A|/)' + Regexp.escape($~[1]) + '/.*(/|\z)'
           elsif pattern.match(%r{\A\*/(.+)\z})
             # */something (match files or directories at any level)
-            '(\A|/)' + Regexp.escape($~[1]) + '(/|\z)'
-          elsif pattern.match(%r{\A\*/([^*]+)/*\z})
-            # */something/* (match directories at any level)
             '(\A|/)' + Regexp.escape($~[1]) + '(/|\z)'
           end
         end.compact.join('|')

--- a/ruby/command-t/lib/command-t/vim.rb
+++ b/ruby/command-t/lib/command-t/vim.rb
@@ -83,7 +83,7 @@ module CommandT
             '\.' + Regexp.escape($~[1]) + '\z'
           elsif pattern.match(%r{\A\*/([^/]+)/\*\z})
             # */something/* (match directories at any level)
-            '(\A|/)' + Regexp.escape($~[1]) + '/.*(/|\z)'
+            '(\A|/)' + Regexp.escape($~[1]) + '/.+'
           elsif pattern.match(%r{\A\*/(.+)\z})
             # */something (match files or directories at any level)
             '(\A|/)' + Regexp.escape($~[1]) + '(/|\z)'

--- a/spec/command-t/vim_spec.rb
+++ b/spec/command-t/vim_spec.rb
@@ -11,4 +11,12 @@ describe CommandT::VIM do
       expect(CommandT::VIM.escape_for_single_quotes(input)).to eq(expected)
     end
   end
+
+  describe '.wildignore_to_regexp' do
+    it 'properly matches directories at any level' do
+      regexp = Regexp.new(CommandT::VIM.wildignore_to_regexp('*/foo/*'))
+      expect(regexp).to match('some/path/to/foo/file.js')
+      expect(regexp).to_not match('some/path/to/foo')
+    end
+  end
 end

--- a/spec/command-t/vim_spec.rb
+++ b/spec/command-t/vim_spec.rb
@@ -13,10 +13,68 @@ describe CommandT::VIM do
   end
 
   describe '.wildignore_to_regexp' do
-    it 'properly matches directories at any level' do
-      regexp = Regexp.new(CommandT::VIM.wildignore_to_regexp('*/foo/*'))
-      expect(regexp).to match('some/path/to/foo/file.js')
-      expect(regexp).to_not match('some/path/to/foo')
+    subject do
+      Regexp.new(CommandT::VIM.wildignore_to_regexp(wildignore))
+    end
+
+    describe '"foo"' do
+      let(:wildignore) { 'foo' }
+
+      it 'matches the right strings' do
+        expect(subject).to_not match('a.foo')
+        expect(subject).to_not match('a/b.foo')
+        expect(subject).to match('foo')
+        expect(subject).to match('a/foo')
+        expect(subject).to_not match('a/foo/b')
+      end
+    end
+
+    describe '".foo"' do
+      let(:wildignore) { '*.foo' }
+
+      it 'matches the right strings' do
+        expect(subject).to match('a.foo')
+        expect(subject).to match('a/b.foo')
+        expect(subject).to_not match('foo')
+        expect(subject).to_not match('a/foo')
+        expect(subject).to_not match('a/foo/b')
+      end
+    end
+
+    describe '"*/foo/*"' do
+      let(:wildignore) { '*/foo' }
+
+      it 'matches the right strings' do
+        expect(subject).to_not match('a.foo')
+        expect(subject).to_not match('a/b.foo')
+        expect(subject).to match('foo')
+        expect(subject).to match('a/foo')
+        expect(subject).to match('a/foo/b')
+      end
+    end
+
+    describe '"*/foo/*"' do
+      let(:wildignore) { '*/foo/*' }
+
+      it 'matches the right strings' do
+        expect(subject).to_not match('a.foo')
+        expect(subject).to_not match('a/b.foo')
+        expect(subject).to_not match('foo')
+        expect(subject).to_not match('a/foo')
+        expect(subject).to match('a/foo/b')
+      end
+    end
+
+    describe 'multiple patterns' do
+      let(:wildignore) { '*.foo,*/foo/*' }
+
+      it 'matches the right strings' do
+        expect(subject).to match('a.foo')
+        expect(subject).to match('a/b.foo')
+        expect(subject).to_not match('foo')
+        expect(subject).to_not match('a/foo')
+        expect(subject).to match('a/foo/b')
+      end
     end
   end
 end


### PR DESCRIPTION
I was trying to get rid of files inside dist folders in my command-t
search results. So I added this to my wildignore setting for vim:

  `*/dist/*`

...which didn't seem to have any effect. I'm using watchman, so at first
I thought that there might some cache that needs to be invalidated. But
`watchman watch-del <path>` didn't help.

I decided to change the wildignore pattern to `*/dist`. This worked, and
didn't require any cache invalidation.

Digging through the code, I found a simple way to reproduce the but in
an rspec test. So I decided to fix it, by
- Flipping the order between the `*/something` pattern and the
`*/something/*` pattern, to deal with the most complicated pattern
first.
- Changing the matching pattern to look for a slash instead of a star.
- Changing the resulting regexp to include the slash plus anything
after.