### PR TITLE
Fix RangeError in NUM2LONG conversion on Windows x64

### DIFF
--- a/ruby/command-t/ext/command-t/matcher.c
+++ b/ruby/command-t/ext/command-t/matcher.c
@@ -245,7 +245,7 @@ VALUE CommandTMatcher_sorted_matches_for(int argc, VALUE *argv, VALUE self)
     last_needle = rb_ivar_get(self, rb_intern("last_needle"));
     if (
         NIL_P(paths_object_id) ||
-        NUM2LONG(new_paths_object_id) != NUM2LONG(paths_object_id)
+        rb_equal(new_paths_object_id, paths_object_id) != Qtrue
     ) {
         // `paths` changed, need to replace matches array.
         paths_object_id = new_paths_object_id;


### PR DESCRIPTION
I was hitting an issue on 64-bit Windows where on every search it would hit ``RangeError: bignum too big to
convert into `long'``. This error was due to some NUM2LONG conversions - I suspect it's because on 64-bit Windows, long (32 bits) is too small to fit a pointer (64 bits)? I think it's enough to compare object ids directly with `rb_equal`, and doing so fixes the error for me.