### PR TITLE
Add new file scanner: rg (ripgrep)

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -774,6 +774,11 @@ Following is a list of all available options:
         work on systems without the tool or with an incompatible version of
         the tool.
 
+      - "rg": uses the command-line tool of the same name, also known as
+        "ripgrep", which respects gitignore rules and can be very fast on
+        large projects because it is written in Rust, but may not work on
+        systems without the tool or with an incompatible version of the tool.
+
       - "git": uses `git ls-files` to quickly produce a list of files; when
         Git isn't available or the path being searched is not inside a Git
         repository falls back to "find".

--- a/ruby/command-t/lib/command-t/finder/file_finder.rb
+++ b/ruby/command-t/lib/command-t/finder/file_finder.rb
@@ -14,6 +14,8 @@ module CommandT
           @scanner = Scanner::FileScanner::WatchmanFileScanner.new(path, options)
         when 'git'
           @scanner = Scanner::FileScanner::GitFileScanner.new(path, options)
+        when 'rg'
+          @scanner = Scanner::FileScanner::RipgrepFileScanner.new(path, options)
         else
           raise ArgumentError, "unknown scanner type '#{options[:scanner]}'"
         end

--- a/ruby/command-t/lib/command-t/scanner/file_scanner.rb
+++ b/ruby/command-t/lib/command-t/scanner/file_scanner.rb
@@ -12,6 +12,7 @@ module CommandT
       # Subclasses
       autoload :FindFileScanner,     'command-t/scanner/file_scanner/find_file_scanner'
       autoload :GitFileScanner,      'command-t/scanner/file_scanner/git_file_scanner'
+      autoload :RipgrepFileScanner,  'command-t/scanner/file_scanner/rg_file_scanner'
       autoload :RubyFileScanner,     'command-t/scanner/file_scanner/ruby_file_scanner'
       autoload :WatchmanFileScanner, 'command-t/scanner/file_scanner/watchman_file_scanner'
 

--- a/ruby/command-t/lib/command-t/scanner/file_scanner/rg_file_scanner.rb
+++ b/ruby/command-t/lib/command-t/scanner/file_scanner/rg_file_scanner.rb
@@ -1,0 +1,57 @@
+# Copyright 2014-present Greg Hurrell. All rights reserved.
+# Licensed under the terms of the BSD 2-clause license.
+
+require 'open3'
+
+module CommandT
+  class Scanner
+    class FileScanner
+      # A FileScanner which shells out to the `rg` executable in order to scan.
+      class RipgrepFileScanner < FileScanner
+        include PathUtilities
+
+        def paths!
+          # temporarily set field separator to NUL byte; this setting is
+          # respected by both `each_line` and `chomp!` below, and makes it easier
+          # to parse the output of `find -print0`
+          separator = $/
+          $/ = "\x00"
+
+          unless @scan_dot_directories
+            dot_directory_filter = [
+              '--glob', "!#{@path}/.*/*",   # top-level dot dir
+              '--glob', "!#{@path}/*/.*/*"  # lower-level dot dir
+            ]
+          end
+
+          paths = []
+          Open3.popen3(*([
+            'rg', '--follow',               # follow symlinks
+            @path,                          # anchor search here
+            '--maxdepth', @max_depth.to_s,  # limit depth of DFS
+            '--files',                      # only show files (not dirs etc)
+            '--hidden',                     # include hidden files and directories
+            dot_directory_filter,           # possibly skip out dot directories
+            '--null'                        # NUL-terminate results
+          ].flatten.compact)) do |stdin, stdout, stderr|
+            counter = 1
+            next_progress = progress_reporter.update(counter)
+            stdout.each_line do |line|
+              next if path_excluded?(line.chomp!)
+              paths << line[@prefix_len..-1]
+              next_progress = progress_reporter.update(counter) if counter == next_progress
+              if (counter += 1) > @max_files
+                show_max_files_warning
+                break
+              end
+            end
+          end
+          paths
+        ensure
+          $/ = separator
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
It works very similarly to the find(1) scanner but uses ripgrep[1] as
the underlying tool.  Ripgrep is primarily a replacement for grep(1) but
can be used in a way similar to find(1).  It respects gitignore rules,
which can be an advantage over the find(1) scanner, but it only lists
files under $PWD, which can be an advantage over the git(1) scanner.

[1]: https://github.com/BurntSushi/ripgrep