### PR TITLE
fix CommandTOpen (GotoOrOpen) command

### DIFF
--- a/autoload/commandt.vim
+++ b/autoload/commandt.vim
@@ -140,7 +140,7 @@ function! commandt#CheckBuffer(buffer_number) abort
 endfunction
 
 " visible == exists, loaded, listed and not hidden
-" (buffer is opened in window - in current or another tab)
+" (buffer is opened in a window - in current or another tab)
 function! s:BufVisible(buffer)
   " buffer is opened in current tab (quick check for current tab)
   if bufwinnr('^' . a:buffer . '$') != -1 | return 1 | end

--- a/autoload/commandt.vim
+++ b/autoload/commandt.vim
@@ -139,21 +139,34 @@ function! commandt#CheckBuffer(buffer_number) abort
   endif
 endfunction
 
-function! s:BufHidden(buffer)
-  let bufno = bufnr(a:buffer)
-  let listed_buffers = ''
+" visible == exists, loaded, listed and not hidden
+" (buffer is opened in window - in current or another tab)
+function! s:BufVisible(buffer)
+  " buffer is opened in current tab (quick check for current tab)
+  if bufwinnr('^' . a:buffer . '$') != -1 | return 1 | end
+  " buffer exists if it has been opened at least once (unless wiped)
+  if !bufexists(a:buffer) | return 0 | end
+  " buffer is not loaded when its last window is closed (`set nohidden` only)
+  if !bufloaded(a:buffer) | return 0 | end
+  " buffer is not listed when it's deleted
+  if !buflisted(a:buffer) | return 0 | end
 
-  redir => listed_buffers
+  let bufno = bufnr(a:buffer)
+  let ls_buffers = ''
+
+  redir => ls_buffers
   silent ls
   redir END
 
-  for line in split(listed_buffers, "\n")
+  " buffer is hidden when its last window is closed (`set hidden` only)
+  for line in split(ls_buffers, "\n")
     let components = split(line)
     if components[0] == bufno
-      return match(components[1], 'h') != -1
+      return match(components[1], 'h') == -1
     endif
   endfor
-  return 0
+
+  return 1
 endfunction
 
 function! commandt#GotoOrOpen(command_and_args) abort
@@ -164,8 +177,7 @@ function! commandt#GotoOrOpen(command_and_args) abort
   " `bufwinnr()` doesn't see windows in other tabs, meaning we open them again
   " instead of switching to the other tab; but `bufname()` sees hidden
   " buffers, and if we try to open one of those, we get an unwanted split.
-  if bufwinnr('^' . l:file . '$') != -1 ||
-        \ (bufname('^' . l:file . '$') !=# '' && !s:BufHidden(l:file))
+  if s:BufVisible(l:file)
     execute 'sbuffer ' . l:file
   else
     execute l:command . l:file


### PR DESCRIPTION
PR should fix #311 and maybe #314.

PR fixes `GotoOrOpen` command: now `GotoOrOpen` command uses `sbuffer` only if buffer is visible in current or some other tab (new `BufVisible` function checks that buffer exists, that it's loaded, listed and not hidden).

Steps to reproduce the bug:

- `set hidden` in .vimrc
- `let g:CommandTAcceptSelectionTabCommand = 'CommandTOpen tabe'`
- open any file in a new tab with `<C-t>` from Command-T
- delete its buffer with `:bd`
- open that file in a new tab with `<C-t>` again

=> file is opened in horizontal split instead of a new tab.

Also I checked behaviour with `set nohidden` - everything seems to work correctly.