### PR TITLE
Support configuring a list of scanners

### DIFF
--- a/ruby/command-t/lib/command-t/controller.rb
+++ b/ruby/command-t/lib/command-t/controller.rb
@@ -579,7 +579,7 @@ module CommandT
         :never_show_dot_files   => VIM::get_bool('g:CommandTNeverShowDotFiles'),
         :scan_dot_directories   => VIM::get_bool('g:CommandTScanDotDirectories'),
         :wildignore             => wildignore,
-        :scanner                => VIM::get_string('g:CommandTFileScanner'),
+        :scanner                => VIM::get_list_or_string('g:CommandTFileScanner'),
         :git_scan_submodules    => VIM::get_bool('g:CommandTGitScanSubmodules'),
         :git_include_untracked  => VIM::get_bool('g:CommandTGitIncludeUntracked')
     end

--- a/ruby/command-t/lib/command-t/finder/file_finder.rb
+++ b/ruby/command-t/lib/command-t/finder/file_finder.rb
@@ -5,19 +5,7 @@ module CommandT
   class Finder
     class FileFinder < Finder
       def initialize(path = Dir.pwd, options = {})
-        case options.delete(:scanner)
-        when 'ruby', nil # ruby is the default
-          @scanner = Scanner::FileScanner::RubyFileScanner.new(path, options)
-        when 'find'
-          @scanner = Scanner::FileScanner::FindFileScanner.new(path, options)
-        when 'watchman'
-          @scanner = Scanner::FileScanner::WatchmanFileScanner.new(path, options)
-        when 'git'
-          @scanner = Scanner::FileScanner::GitFileScanner.new(path, options)
-        else
-          raise ArgumentError, "unknown scanner type '#{options[:scanner]}'"
-        end
-
+        @scanner = scanner(options.delete(:scanner), path, options)
         @matcher = Matcher.new @scanner, options
       end
 
@@ -27,6 +15,23 @@ module CommandT
 
       def name
         'Files'
+      end
+
+    private
+
+      def scanner(name, path, options)
+        case name
+        when 'ruby', nil # ruby is the default
+          Scanner::FileScanner::RubyFileScanner.new(path, options)
+        when 'find'
+          Scanner::FileScanner::FindFileScanner.new(path, options)
+        when 'watchman'
+          Scanner::FileScanner::WatchmanFileScanner.new(path, options)
+        when 'git'
+          Scanner::FileScanner::GitFileScanner.new(path, options)
+        else
+          raise ArgumentError, "unknown scanner type '#{which}'"
+        end
       end
     end
   end

--- a/ruby/command-t/lib/command-t/finder/file_finder.rb
+++ b/ruby/command-t/lib/command-t/finder/file_finder.rb
@@ -19,8 +19,8 @@ module CommandT
 
     private
 
-      def scanner(name, path, options)
-        case name
+      def scanner(which, path, options)
+        case which
         when 'ruby', nil # ruby is the default
           Scanner::FileScanner::RubyFileScanner.new(path, options)
         when 'find'
@@ -29,6 +29,9 @@ module CommandT
           Scanner::FileScanner::WatchmanFileScanner.new(path, options)
         when 'git'
           Scanner::FileScanner::GitFileScanner.new(path, options)
+        when Enumerable
+          scanners = which.map { |name| scanner(name, path, options) }
+          Scanner::FileScanner::CompositeFileScanner.new(scanners)
         else
           raise ArgumentError, "unknown scanner type '#{which}'"
         end

--- a/ruby/command-t/lib/command-t/scanner/file_scanner.rb
+++ b/ruby/command-t/lib/command-t/scanner/file_scanner.rb
@@ -10,10 +10,11 @@ module CommandT
     # RubyFileScanner and FindFileScanner subclasses).
     class FileScanner < Scanner
       # Subclasses
-      autoload :FindFileScanner,     'command-t/scanner/file_scanner/find_file_scanner'
-      autoload :GitFileScanner,      'command-t/scanner/file_scanner/git_file_scanner'
-      autoload :RubyFileScanner,     'command-t/scanner/file_scanner/ruby_file_scanner'
-      autoload :WatchmanFileScanner, 'command-t/scanner/file_scanner/watchman_file_scanner'
+      autoload :FindFileScanner,      'command-t/scanner/file_scanner/find_file_scanner'
+      autoload :GitFileScanner,       'command-t/scanner/file_scanner/git_file_scanner'
+      autoload :RubyFileScanner,      'command-t/scanner/file_scanner/ruby_file_scanner'
+      autoload :WatchmanFileScanner,  'command-t/scanner/file_scanner/watchman_file_scanner'
+      autoload :CompositeFileScanner, 'command-t/scanner/file_scanner/composite_file_scanner'
 
       attr_accessor :path
 

--- a/ruby/command-t/lib/command-t/scanner/file_scanner/composite_file_scanner.rb
+++ b/ruby/command-t/lib/command-t/scanner/file_scanner/composite_file_scanner.rb
@@ -1,0 +1,37 @@
+module CommandT
+  class Scanner
+    class FileScanner
+      class CompositeFileScanner
+        def initialize(scanners)
+          @scanners = scanners
+        end
+
+        def paths
+          try_paths
+        end
+
+        def path=(path)
+          @scanners.each do |scanner|
+            scanner.path = path
+          end
+        end
+
+        def flush
+          @scanners.each do |scanner|
+            scanner.flush
+          end
+        end
+
+      private
+
+        def try_paths(enum = @scanners.to_enum)
+          enum.next.paths
+        rescue RuntimeError, Errno::ENOENT
+          try_paths(enum)
+        rescue StopIteration
+          raise RuntimeError, 'No scanners left'
+        end
+      end
+    end
+  end
+end

--- a/ruby/command-t/lib/command-t/scanner/file_scanner/git_file_scanner.rb
+++ b/ruby/command-t/lib/command-t/scanner/file_scanner/git_file_scanner.rb
@@ -39,11 +39,6 @@ module CommandT
             end
             truncated.to_a
           end
-        rescue LsFilesError
-          super
-        rescue Errno::ENOENT
-          # git executable not present and executable
-          super
         end
 
       private

--- a/ruby/command-t/lib/command-t/scanner/file_scanner/watchman_file_scanner.rb
+++ b/ruby/command-t/lib/command-t/scanner/file_scanner/watchman_file_scanner.rb
@@ -9,10 +9,7 @@ module CommandT
     class FileScanner
       # A FileScanner which delegates the heavy lifting to Watchman
       # (https://github.com/facebook/watchman); useful for very large hierarchies.
-      #
-      # Inherits from FindFileScanner so that it can fall back to it in the event
-      # that Watchman isn't available or able to fulfil the request.
-      class WatchmanFileScanner < FindFileScanner
+      class WatchmanFileScanner < FileScanner
         # Exception raised when Watchman is unavailable or unable to process the
         # requested path.
         WatchmanError = Class.new(::RuntimeError)
@@ -49,9 +46,6 @@ module CommandT
               extracted
             end
           end
-        rescue Errno::ENOENT, WatchmanError
-          # watchman executable not present, or unable to fulfil request
-          super
         end
 
       private


### PR DESCRIPTION
**Note**: This is a **work in progress**!

This changeset allows users to configure a _list_ of scanners to try in order, like

```vim
let g:CommandTFileScanner = ['watchman', 'git', 'find', 'ruby']
```

by providing a composite file scanner that has a list of scanners it delegates to.
Configuring a single value is still supported so we don’t break users’ configuration.

This  also allows us to drop the hardcoded fallback mechanisms used by the `watchman` and `git` scanners.

Some open points:
* [ ] Is this even something we want?
* [ ] Add/Change the documentation
* [ ] Add tests
* [ ] Consider a new default value? (`['git', 'find', 'ruby']` seems safe)
* [ ] Handle configuration problems gracefully
* [ ] Improve looping code in the composite scanner
    ([mkhl/simplify-composite](https://github.com/mkhl/command-t/compare/composite...mkhl:simplify-composite) seems simpler but doesn’t raise when all scanners fail)
* [ ] Improve control flow in/to the composite scanner
    (we currently just silently skip scanners that raise RuntimeError or ENOENT)
* [ ] Do something with caching?
    (This leaves it in the actual scanners, we could pull it up into the composite, or into a whole separate layer.)