### PR TITLE
doc: Add a note explaining a potential Dein version mismatch issue

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -446,6 +446,13 @@ during the build:
   ruby extconf.rb
   make
 
+If you are using the Dein plugin manager, you may run into a Ruby version
+mismatch even if the Command-T and Vim Ruby versions ostensibly match. This
+may be because Dein is running a cached version of the plugin. You can force
+it to run the current version using:
+
+  :call dein#recache_runtimepath()
+
 
 USAGE                                           *command-t-usage*
 


### PR DESCRIPTION
After almost going insane over a seemingly impossible version mismatch, I finally stumbled upon kuon's solution in https://github.com/wincent/command-t/issues/196#issuecomment-279267026.

I figured that a note in the troubleshooting section might save other Dein users some hair-pulling.