### PR TITLE
deleting a buffer closes the finder window

### DIFF
--- a/ruby/command-t/lib/command-t/controller.rb
+++ b/ruby/command-t/lib/command-t/controller.rb
@@ -228,6 +228,7 @@ module CommandT
         ::VIM::command "bd #{selection}"
       end
       list_matches!
+      hide
     end
     guard :remove_buffer
 


### PR DESCRIPTION
Currently if you delete the buffer the finder window is not closed and almost any action post deletion throws errors as the list is not correctly updated. Closing the list after a deletion is a convenient and easy way to fix this issue.