### PR TITLE
Let wildcards without a period work.

### DIFF
--- a/ruby/command-t/lib/command-t/vim.rb
+++ b/ruby/command-t/lib/command-t/vim.rb
@@ -79,9 +79,9 @@ module CommandT
           elsif pattern.match(%r{\A\*\.([^*]+)\z})
             # *.something (match file with extension at any level)
             '\.' + Regexp.escape($~[1]) + '\z'
-          elsif pattern.match(%r{\A\*([^*]+)\z})
-            # *something (match file with extension without dot at any level)
-            Regexp.escape($~[1]) + '\z'
+          elsif pattern.match(%r{\A\*([^/*.][^/*]*)\z})
+            # *something (match file with extension without front dot at any level)
+            '[^/]+' +  Regexp.escape($~[1]) + '\z'
           elsif pattern.match(%r{\A\*/([^/]+)/\*\z})
             # */something/* (match directories at any level)
             '(\A|/)' + Regexp.escape($~[1]) + '/.+'

--- a/ruby/command-t/lib/command-t/vim.rb
+++ b/ruby/command-t/lib/command-t/vim.rb
@@ -79,6 +79,9 @@ module CommandT
           elsif pattern.match(%r{\A\*\.([^*]+)\z})
             # *.something (match file with extension at any level)
             '\.' + Regexp.escape($~[1]) + '\z'
+          elsif pattern.match(%r{\A\*([^*]+)\z})
+            # *something (match file with extension without dot at any level)
+            Regexp.escape($~[1]) + '\z'
           elsif pattern.match(%r{\A\*/([^/]+)/\*\z})
             # */something/* (match directories at any level)
             '(\A|/)' + Regexp.escape($~[1]) + '/.+'


### PR DESCRIPTION

This fix lets wildcards without a period - ie,  `*~`,  Vim's default back up extension - to be hidden from file lists.


