### PR TITLE
Use rspec-mock for stubbing.

### DIFF
--- a/.github/workfows/tests.yaml
+++ b/.github/workfows/tests.yaml
@@ -1,0 +1,22 @@
+name: tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install libraries
+        run: |
+          set -x
+          sudo apt-get update -q || :
+          sudo apt-get install --no-install-recommends -q -y build-essential ruby-dev ruby-
+      - name: Build extension
+        run: |
+          pushd ./ruby/command-t/ext/command-t
+          ruby extconf.rb --vendor
+          make
+          popd
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake

--- a/spec/command-t/controller_spec.rb
+++ b/spec/command-t/controller_spec.rb
@@ -16,35 +16,35 @@ describe CommandT::Controller do
     end
 
     def set_string(name, value)
-      stub(::VIM).evaluate(%{exists("#{name}")}).returns(1)
-      stub(::VIM).evaluate(name).returns(value)
+      allow(::VIM).to receive(:evaluate).with(%{exists("#{name}")}).and_return(1)
+      allow(::VIM).to receive(:evaluate).with(name).and_return(value)
     end
 
     it 'opens relative paths inside the working directory' do
-      stub(::VIM).evaluate('a:arg').returns('')
+      allow(::VIM).to receive(:evaluate).with('a:arg').and_return('')
       set_string('g:CommandTTraverseSCM', 'pwd')
       controller.show_file_finder
-      mock(::VIM).command('silent CommandTOpen edit path/to/selection')
+      expect(::VIM).to receive(:command).with('silent CommandTOpen edit path/to/selection')
       controller.accept_selection
     end
 
     it 'opens absolute paths outside the working directory' do
-      stub(::VIM).evaluate('a:arg').returns('../outside')
+      allow(::VIM).to receive(:evaluate).with('a:arg').and_return('../outside')
       controller.show_file_finder
-      mock(::VIM).command('silent CommandTOpen edit /working/outside/path/to/selection')
+      expect(::VIM).to receive(:command).with('silent CommandTOpen edit /working/outside/path/to/selection')
       controller.accept_selection
     end
 
     it 'does not get confused by common directory prefixes' do
-      stub(::VIM).evaluate('a:arg').returns('../directory-oops')
+      allow(::VIM).to receive(:evaluate).with('a:arg').and_return('../directory-oops')
       controller.show_file_finder
-      mock(::VIM).command('silent CommandTOpen edit /working/directory-oops/path/to/selection')
+      expect(::VIM).to receive(:command).with('silent CommandTOpen edit /working/directory-oops/path/to/selection')
       controller.accept_selection
     end
 
     it 'does not enter an infinite loop when toggling focus' do
       # https://github.com/wincent/command-t/issues/157
-      stub(::VIM).evaluate('a:arg').returns('')
+      allow(::VIM).to receive(:evaluate).with('a:arg').and_return('')
       set_string('g:CommandTTraverseSCM', 'pwd')
       controller.show_file_finder
       expect { controller.toggle_focus }.to_not raise_error
@@ -59,43 +59,43 @@ describe CommandT::Controller do
 
   def stub_finder(sorted_matches=[])
     finder = CommandT::Finder::FileFinder.new
-    stub(finder).path = anything
-    stub(finder).sorted_matches_for(anything, anything).returns(sorted_matches)
-    stub(CommandT::Finder::FileFinder).new.returns(finder)
+    allow(finder).to receive(:"path=").with(anything)
+    allow(finder).to receive(:sorted_matches_for).with(anything, anything).and_return(sorted_matches)
+    allow(CommandT::Finder::FileFinder).to receive(:new).and_return(finder)
   end
 
   def stub_match_window(selection)
     match_window = Object.new
-    stub(match_window).matches = anything
-    stub(match_window).leave
-    stub(match_window).focus
-    stub(match_window).selection.returns(selection)
-    stub(CommandT::MatchWindow).new.returns(match_window)
+    allow(match_window).to receive(:"matches=").with(anything)
+    allow(match_window).to receive(:leave)
+    allow(match_window).to receive(:focus)
+    allow(match_window).to receive(:selection).and_return(selection)
+    allow(CommandT::MatchWindow).to receive(:new).and_return(match_window)
   end
 
   def stub_prompt(abbrev='')
     prompt = Object.new
-    stub(prompt).focus
-    stub(prompt).unfocus
-    stub(prompt).clear!
-    stub(prompt).redraw
-    stub(prompt).abbrev.returns(abbrev)
-    stub(CommandT::Prompt).new.returns(prompt)
+    allow(prompt).to receive(:focus)
+    allow(prompt).to receive(:unfocus)
+    allow(prompt).to receive(:clear!)
+    allow(prompt).to receive(:redraw)
+    allow(prompt).to receive(:abbrev).and_return(abbrev)
+    allow(CommandT::Prompt).to receive(:new).and_return(prompt)
   end
 
   def stub_vim(working_directory)
-    stub($curbuf).number.returns('0')
-    stub(::VIM).command(/noremap/)
-    stub(::VIM).command('silent b 0')
-    stub(::VIM).command(/augroup/)
-    stub(::VIM).command('au!')
-    stub(::VIM).command(/autocmd/)
-    stub(::VIM).evaluate(/exists\(.+\)/).returns('0')
-    stub(::VIM).evaluate('getcwd()').returns(working_directory)
-    stub(::VIM).evaluate('&buflisted').returns('1')
-    stub(::VIM).evaluate('&lines').returns('80')
-    stub(::VIM).evaluate('&term').returns('vt100')
-    stub(::VIM).evaluate('v:version').returns(704)
-    stub(::VIM).evaluate('!&buflisted && &buftype == "nofile"')
+    allow($curbuf).to receive(:number).and_return('0')
+    allow(::VIM).to receive(:command).with(/noremap/)
+    allow(::VIM).to receive(:command).with('silent b 0')
+    allow(::VIM).to receive(:command).with(/augroup/)
+    allow(::VIM).to receive(:command).with('au!')
+    allow(::VIM).to receive(:command).with(/autocmd/)
+    allow(::VIM).to receive(:evaluate).with(/exists\(.+\)/).and_return('0')
+    allow(::VIM).to receive(:evaluate).with('getcwd()').and_return(working_directory)
+    allow(::VIM).to receive(:evaluate).with('&buflisted').and_return('1')
+    allow(::VIM).to receive(:evaluate).with('&lines').and_return('80')
+    allow(::VIM).to receive(:evaluate).with('&term').and_return('vt100')
+    allow(::VIM).to receive(:evaluate).with('v:version').and_return(704)
+    allow(::VIM).to receive(:evaluate).with('!&buflisted && &buftype == "nofile"')
   end
 end

--- a/spec/command-t/finder/buffer_finder_spec.rb
+++ b/spec/command-t/finder/buffer_finder_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 describe CommandT::Finder::BufferFinder do
   before do
     @paths = %w(.git/config .vim/notes .vimrc baz foo/beta)
-    any_instance_of(CommandT::Scanner::BufferScanner, :paths => @paths)
+    allow_any_instance_of(CommandT::Scanner::BufferScanner).to receive(:paths).and_return(@paths)
     @finder = CommandT::Finder::BufferFinder.new
   end
 

--- a/spec/command-t/finder/file_finder_spec.rb
+++ b/spec/command-t/finder/file_finder_spec.rb
@@ -19,9 +19,9 @@ describe CommandT::Finder::FileFinder do
   end
 
   before do
-    stub(::VIM).evaluate(/expand/) { 0 }
-    stub(::VIM).command(/echon/)
-    stub(::VIM).command('redraw')
+    allow(::VIM).to receive(:evaluate).with(/expand/) { 0 }
+    allow(::VIM).to receive(:command).with(/echon/)
+    allow(::VIM).to receive(:command).with('redraw')
   end
 
   describe 'sorted_matches_for method' do

--- a/spec/command-t/scanner/buffer_scanner_spec.rb
+++ b/spec/command-t/scanner/buffer_scanner_spec.rb
@@ -14,10 +14,10 @@ describe CommandT::Scanner::BufferScanner do
   before do
     @paths = %w(bar/abc bar/xyz baz bing foo/alpha/t1 foo/alpha/t2 foo/beta)
     @scanner = CommandT::Scanner::BufferScanner.new
-    stub(@scanner).relative_path_under_working_directory(is_a(String)) { |arg| arg }
-    stub(::VIM::Buffer).count { 7 }
+    allow(@scanner).to receive(:relative_path_under_working_directory).with(kind_of(String)) { |arg| arg }
+    allow(::VIM::Buffer).to receive(:count) { 7 }
     (0..6).each do |n|
-      stub(::VIM::Buffer)[n].returns(buffer @paths[n])
+      allow(::VIM::Buffer).to receive(:'[]').with(n).and_return(buffer @paths[n])
     end
   end
 

--- a/spec/command-t/scanner/file_scanner/ruby_file_scanner_spec.rb
+++ b/spec/command-t/scanner/file_scanner/ruby_file_scanner_spec.rb
@@ -11,10 +11,10 @@ describe CommandT::Scanner::FileScanner::RubyFileScanner do
     )
     @scanner = CommandT::Scanner::FileScanner::RubyFileScanner.new(@dir)
 
-    stub(::VIM).evaluate(/exists/) { 1 }
-    stub(::VIM).evaluate(/expand\(.+\)/) { '0' }
-    stub(::VIM).command(/echon/)
-    stub(::VIM).command('redraw')
+    allow(::VIM).to receive(:evaluate).with(/exists/) { 1 }
+    allow(::VIM).to receive(:evaluate).with(/expand\(.+\)/) { '0' }
+    allow(::VIM).to receive(:command).with(/echon/)
+    allow(::VIM).to receive(:command).with('redraw')
   end
 
   describe 'paths method' do

--- a/spec/command-t/scanner/file_scanner/watchman_file_scanner_spec.rb
+++ b/spec/command-t/scanner/file_scanner/watchman_file_scanner_spec.rb
@@ -8,14 +8,12 @@ describe CommandT::Scanner::FileScanner::WatchmanFileScanner do
     it 'falls back to the FindFileScanner' do
       # fake an error
       scanner = described_class.new
-      stub(scanner).get_raw_sockname do
+      allow(scanner).to receive(:get_raw_sockname) do
         raise described_class::WatchmanError
       end
 
       # expect call on superclass
-      any_instance_of(CommandT::Scanner::FileScanner::FindFileScanner) do |klass|
-        mock(klass).paths!
-      end
+      expect_any_instance_of(CommandT::Scanner::FileScanner::FindFileScanner).to receive(:paths!)
 
       scanner.paths!
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,10 +16,6 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'command-t'
 require 'command-t/ext'
 
-RSpec.configure do |config|
-  config.mock_framework = :rr
-end
-
 # Fake top-level VIM implementation, for stubbing.
 module VIM
   class << self


### PR DESCRIPTION
Since RR gem was updated in Fedora from 1.1.2 to 1.2.1, the test suite fails with errors such as:

~~~
Failures:
  1) CommandT::Controller accept selection opens relative paths inside the working directory
     Failure/Error: stub(finder).path = anything
     NoMethodError:
       undefined method `stub' for #<RSpec::ExampleGroups::CommandTController::AcceptSelection "opens relative paths inside the working directory" (./spec/command-t/controller_spec.rb:23)>
     # ./spec/command-t/controller_spec.rb:62:in `stub_finder'
     # ./spec/command-t/controller_spec.rb:12:in `block (3 levels) in <top (required)>'

... snip ...

Finished in 0.04789 seconds (files took 0.14141 seconds to load)
121 examples, 26 failures, 1 pending

... snip ...
~~~

This seems to be due some backward incompatible changes in RR together with RR probably being [incompatible with RSpec 3.x](https://github.com/rr/rr/issues/65).

Therefore, I have used [rr-to-rspec-converter](https://github.com/kjvarga/rr-to-rspec-converter) with a several small tweaks and converted the test suite to use rspec-mocks. Looking at the result, I don't find the output too different or harder to read, therefore I propose to change the mock framework from RR to rspec-mocks. This allows to reduce the dependency chain, which is always good thing IMO.