### PR TITLE
Add g:CommandTDontGoto option

### DIFF
--- a/autoload/commandt.vim
+++ b/autoload/commandt.vim
@@ -173,7 +173,7 @@ function! commandt#GotoOrOpen(command_and_args) abort
   " `bufwinnr()` doesn't see windows in other tabs, meaning we open them again
   " instead of switching to the other tab; but `bufname()` sees hidden
   " buffers, and if we try to open one of those, we get an unwanted split.
-  if s:BufVisible(l:file)
+  if (!exists("g:CommandTDontGoto") || g:CommandTDontGoto == 0) && s:BufVisible(l:file)
     execute 'sbuffer ' . l:file
   else
     execute l:command . l:file

--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -1035,6 +1035,14 @@ Following is a list of all available options:
       When typing a search term into Command-T, ignore spaces. When set to 0,
       Command-T will search for literal spaces inside file names.
 
+
+                                             *g:CommandTDontGoto*
+  |g:CommandTDontGoto|                       boolean (default: 0)
+
+      When this setting is off (the default) the default behaviour of
+      CommandTGotoOrOpen is applied. If on, always open buffer, don't goto.
+
+
 As well as the basic options listed above, there are a number of settings that
 can be used to override the default key mappings used by Command-T. For
 example, to set <C-x> as the mapping for cancelling (dismissing) the Command-T


### PR DESCRIPTION
Hello,

In my workflow, I wanted to disable the "goto or open" behaviour of command-t, so I proprose a new configuration option "g:CommandTDontGoto", off by default of course.

Set to "on", the behaviour will be to always open, so one can have multiple windows with the same buffer (which I often happen to have as I use a lot of tabs and jumps).