### PR TITLE
Update Lua mappings documentation

### DIFF
--- a/doc/command-t.txt
+++ b/doc/command-t.txt
@@ -201,9 +201,9 @@ the box. In order to set up the equivalent mappings for Lua, you would add the
 following to your |vimrc| or some other file that gets loaded during
 |startup|:
 >
-    vim.keymap.set('n', '<Leader>b', '<Plug>(CommandTBuffer)', { remap = true })
-    vim.keymap.set('n', '<Leader>j', '<Plug>(CommandTJump)', { remap  = true })
-    vim.keymap.set('n', '<Leader>t', '<Plug>(CommandT)', { remap = true })
+    vim.keymap.set('n', '<Leader>b', '<Plug>(CommandTBuffer)')
+    vim.keymap.set('n', '<Leader>j', '<Plug>(CommandTJump)')
+    vim.keymap.set('n', '<Leader>t', '<Plug>(CommandT)')
 <
 
 What happens if you don't explicitly opt-in to either implementation ~


### PR DESCRIPTION
With https://github.com/neovim/neovim/pull/16969 (which is included in neovim 0.7) neovim always disable the `nore` flag in mappings, so there is no need to be explicit.