### PR TITLE
Use the right git-ls flag for untracked

### DIFF
--- a/lua/wincent/commandt/private/scanners/git.lua
+++ b/lua/wincent/commandt/private/scanners/git.lua
@@ -10,7 +10,7 @@ git.scanner = function(directory, options)
   if options.submodules then
     command = command .. ' --recurse-submodules'
   elseif options.untracked then
-    command = command .. ' --untracked'
+    command = command .. ' --others'
   end
   if directory ~= '' then
     command = command .. ' -- ' .. directory


### PR DESCRIPTION
According to the documentation [git ls-files help][1] the proper flag for untracked files is `--others` and not `--untracked`.

[1]: https://git-scm.com/docs/git-ls-files#Documentation/git-ls-files.txt--o