### PR TITLE
fix: fix scanner.c compile error

### DIFF
--- a/lua/wincent/commandt/lib/scanner.c
+++ b/lua/wincent/commandt/lib/scanner.c
@@ -12,6 +12,7 @@
 #include <stdio.h> /* for fprintf(), stderr */
 #include <stdlib.h> /* for free() */
 #include <string.h> /* for memchr(), strlen() */
+#include <sys/wait.h> /* for wait() */
 #include <unistd.h> /* _exit(), close(), fork(), pipe(), read() */
 
 #include "debug.h"


### PR DESCRIPTION
After cloning the main branch, running `make 4.4.1` with `gcc 14.1.1` on `Linux 6.9.6` in the `lua/wincent/commandt/lib` folder produced

```make
❯ make
cc -Wall -Wextra -Wno-unused-parameter -DMAX_FILES_CONF=134217728 -DMMAP_SLAB_SIZE_CONF=137438953472 -DNDE
BUG -O3 -DLINUX -pthread -shared -fPIC -o commandt.so commandt.c debug.c die.c find.c heap.c matcher.c sca
nner.c score.c str.c watchman.c xmalloc.c xmap.c xstrdup.c
scanner.c: In function ‘commandt_scanner_new_command’:
scanner.c:160:9: error: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]
  160 |     if (wait(&child_pid) == -1) {
      |         ^~~~
make: *** [Makefile:62: commandt.so] Error 1
```

Including `<sys/wait.h>` in `scanner.c` for `wait()` allows for compilation
