### PR TITLE
Make created buffers modifiable, even when the original buffer is not

### DIFF
--- a/lua/wincent/commandt/private/window.lua
+++ b/lua/wincent/commandt/private/window.lua
@@ -219,6 +219,7 @@ function Window:show()
       false, -- listed = false
       true -- scratch = true
     )
+    vim.api.nvim_set_option_value('modifiable', true, {buf=self._main_buffer})
     if self._main_buffer == 0 then
       error('Window:show(): nvim_create_buf() failed')
     end
@@ -331,6 +332,7 @@ function Window:show()
         false, -- listed = false
         true -- scratch = true
       )
+      vim.api.nvim_set_option_value('modifiable', true, {buf=self._title_buffer})
       if self._title_buffer == 0 then
         error('Window:show(): nvim_create_buf() failed')
       end


### PR DESCRIPTION
I have neovim configured with an `autocmd` to `set nomodifiable` when any readonly file is opened.

This reveals a problem -- launching `:CommandT` from such a file fails, as the buffers returned by `nvim_create_buf` seem to inherit this setting from the current buffer.

This PR is a possible fix, explicitly making the created buffers modifiable just after creating them.