### PR TITLE
Remove use of deprecated vim.tbl_flatten

### DIFF
--- a/lua/wincent/commandt/private/validate.lua
+++ b/lua/wincent/commandt/private/validate.lua
@@ -261,7 +261,7 @@ validate_table = function(path, context, options, spec, defaults, config)
       end
     end
   end
-  return vim.tbl_flatten(errors)
+  return vim.iter(errors):flatten():totable()
 end
 
 return validate


### PR DESCRIPTION
I'm attempting to move across to Neovim (using v0.11), and in trying to get a clean bill of of `checkhealth` :

```
WARNING vim.tbl_flatten is deprecated. Feature will be removed in Nvim 0.13
- ADVICE:                                                                  
  - use vim.iter(…):flatten():totable() instead.                           
 ```

Not sure if there's something I'm overlooking, though?